### PR TITLE
Small changes

### DIFF
--- a/lib/class-optimisationio-dashboard.php
+++ b/lib/class-optimisationio-dashboard.php
@@ -621,7 +621,9 @@ class Optimisationio_Dashboard {
 
 	private static function display_stats__cache_and_database_and_wp_disable(){
 		$active_addon = self::addon_activated('cache-performance');
-		$cache_info = $active_addon ? Optimisationio_CacheEnabler::get_optimisation_info() : null;
+		if ( ! $active_addon || ! $cache_info = Optimisationio_CacheEnabler::get_optimisation_info() ) {
+			$cache_info = (object) array( 'size' => 0, 'optimised_size' => 0, 'saving' => 0 );
+		}
 		$wp_disable_active_addon = self::addon_activated('wp-disable');
 		?>
 		<div class="addon-stats">

--- a/lib/class-optimisationio-stats-and-addons.php
+++ b/lib/class-optimisationio-stats-and-addons.php
@@ -206,7 +206,7 @@ class Optimisationio_Stats_And_Addons {
 						}
 					}
 					else{
-						$ret['msg'] = "Dectivation error";
+						$ret['msg'] = "Deactivation error";
 					}
 				}
 				else{

--- a/lib/class-wpperformance-admin.php
+++ b/lib/class-wpperformance-admin.php
@@ -620,7 +620,9 @@ class WpPerformance_Admin {
 						<?php } ?>
 						<li data-tab-setting="tags"><?php esc_html_e('Tags', 'optimisationio'); ?></li>
 						<li data-tab-setting="admin"><?php esc_html_e('Admin', 'optimisationio'); ?></li>
+						<?php if( WpPerformance::should_show_seo_tab() ) { ?>
 						<li data-tab-setting="seo"><?php esc_html_e('SEO', 'optimisationio'); ?></li>
+						<?php } ?>
 						<li data-tab-setting="others"><?php esc_html_e('Others', 'optimisationio'); ?></li>
 					</ul>
 				</div>

--- a/lib/class-wpperformance.php
+++ b/lib/class-wpperformance.php
@@ -11,6 +11,7 @@ class WpPerformance {
 	private $plugin_settings = null;
 
 	private static $enabled_woocommerce = null;
+	private static $show_seo_tab = null;
 
 	/**
 	 * Constructor.
@@ -957,5 +958,12 @@ class WpPerformance {
 			WpPerformance::$enabled_woocommerce = in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) );
 		}
 		return WpPerformance::$enabled_woocommerce;
+	}
+
+	public static function should_show_seo_tab(){
+		if( null === WpPerformance::$show_seo_tab ){
+			WpPerformance::$show_seo_tab = is_plugin_active( 'wordpress-seo/wp-seo.php' );
+		}
+		return WpPerformance::$show_seo_tab;
 	}
 }


### PR DESCRIPTION
Sorry for the crap commit name, wasn't sure what would came through when committing (weird things happening).

This is what changed:
1) There were some notices showing when no data was available yet regarding this;
https://github.com/hosting-io/wp-disable/compare/master...JeroenSormani:small-changes?expand=1#diff-5bfc3ccc6f159410c16dc8331ca05ac1L624

I think this same change has to happen in the WPPerformance plugin, but I couldn't find that repo..

2) A typo

3) Only shows the SEO tab when the WordPress SEO plugin is active. I've left it a bit abstracted so function names will continue to check out when adding support for other SEO plugins for example.