### PR TITLE
ci(deploy): bump upload-artifact to v5 (Node 24)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload built zip as a run artifact
         if: ${{ steps.deploy.outputs.zip-path != '' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: wp-disable-${{ steps.ver.outputs.version }}
           path: ${{ steps.deploy.outputs.zip-path }}


### PR DESCRIPTION
Silences the Node.js 20 deprecation warning on the deploy workflow. No behavior change — same name/path inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)