### PR TITLE
2.0.1: fix readme metadata (contributors + short description)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,16 +1,14 @@
 === WP Disable ===
-Contributors: optimisation.io, hosting.io
+Contributors: pigeonhut
 Tags: disable emoji, disable embeds, remove query strings, performance, optimization
 Requires at least: 6.4
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 2.0.0
+Stable tag: 2.0.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Reduce HTTP requests - Disable Emojis, Disable Gravatars, Disable Embeds and Remove Querystrings. SpeedUp WooCommerce, Added support to disable pingbacks, disable trackbacks, close comments after 28 days, Added the ability to force pagingation after 20 posts,
-Disable WooCommerce scripts and CSS on non WooCommerce Pages, Disable RSS, Disable XML-RPC, Disable Autosave, Remove Windows Live Writer tag, Remove Shortlink Tag, Remove WP API from header and
- many more features to help speed and SEO gains.
+Speed up WordPress by disabling unused features — emojis, embeds, query strings, XML-RPC, RSS and more — for fewer requests and faster pages.
 
 == Description ==
 <strong>Reduce HTTP requests</strong> - Disable Emojis, Disable Gravatars, Disable Embeds and Remove Querystrings. SpeedUp WooCommerce, Added support to disable pingbacks, disable trackbacks, close comments after 28 days, Added the ability to force pagingation after 20 posts,
@@ -77,6 +75,9 @@ You can try our <a href="https://wordpress.org/plugins/wp-image-compression/">Fr
 
 
 == Changelog ==
+= 2.0.1 =
+* Housekeeping: corrected the Contributors field to a valid WordPress.org username and shortened the short description to meet the 150-character directory limit.
+
 = 2.0.0 =
 * Major modernization for current WordPress (6.x) and PHP 7.4+ / 8.x.
 * Removed the obsolete "local Google Analytics" offload (Universal Analytics was sunset by Google in July 2023). Existing GA settings, cron and cache are cleaned up automatically on upgrade.

--- a/wpperformance.php
+++ b/wpperformance.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Disable
  * Plugin URI: https://optimisation.io
  * Description: Improve WordPress performance by disabling unused items. <a href="admin.php?page=optimisationio-dashboard">Open Settings</a>
- * Version: 2.0.0
+ * Version: 2.0.1
  * Requires at least: 6.4
  * Requires PHP: 7.4
  * Author: optimisation.io, hosting.io


### PR DESCRIPTION
Resolves the two author-only warnings from the wp.org import:
- Contributors now uses a valid WordPress.org username (`pigeonhut`).
- Short description shortened to <=150 chars (and no third-party trademark).
- Version/Stable tag bumped to 2.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)