### PR TITLE
chore: gitignore 'to-add or fix' scratch folder

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -24,6 +24,9 @@
 /TODO.md
 /CHANGELOG.md
 
+# Local scratch / working notes
+/to-add or fix
+
 # OS cruft
 .DS_Store
 */.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ phpcs.xml
 # local-only dev tooling (never shipped in the plugin zip)
 scripts/
 dist/
+
+# local scratch / working notes
+to-add or fix/


### PR DESCRIPTION
Keeps the local working-notes folder out of git and the SVN/zip build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)