### PR TITLE
Incorporate PR #7 fixes (SEO tab gating + typo), props @JeroenSormani

### DIFF
--- a/lib/class-optimisationio-dashboard.php
+++ b/lib/class-optimisationio-dashboard.php
@@ -252,7 +252,7 @@ class Optimisationio_Dashboard {
 						}
 					}
 					else{
-						$ret['msg'] = "Dectivation error";
+						$ret['msg'] = "Deactivation error";
 					}
 				}
 				else{

--- a/lib/class-optimisationio-stats-and-addons.php
+++ b/lib/class-optimisationio-stats-and-addons.php
@@ -207,7 +207,7 @@ class Optimisationio_Stats_And_Addons {
 						}
 					}
 					else{
-						$ret['msg'] = "Dectivation error";
+						$ret['msg'] = "Deactivation error";
 					}
 				}
 				else{

--- a/lib/class-wpperformance-admin.php
+++ b/lib/class-wpperformance-admin.php
@@ -548,7 +548,9 @@ class WpPerformance_Admin {
 						<?php } ?>
 						<li data-tab-setting="tags"><?php esc_html_e('Tags', 'wp-disable'); ?></li>
 						<li data-tab-setting="admin"><?php esc_html_e('Admin', 'wp-disable'); ?></li>
+						<?php if( WpPerformance::should_show_seo_tab() ) { ?>
 						<li data-tab-setting="seo"><?php esc_html_e('SEO', 'wp-disable'); ?></li>
+						<?php } ?>
 						<li data-tab-setting="others"><?php esc_html_e('Others', 'wp-disable'); ?></li>
 					</ul>
 				</div>

--- a/lib/class-wpperformance.php
+++ b/lib/class-wpperformance.php
@@ -948,4 +948,15 @@ class WpPerformance {
 		}
 		return WpPerformance::$enabled_woocommerce;
 	}
+
+	/**
+	 * Whether to show the SEO settings tab.
+	 *
+	 * True only when a supported SEO plugin is active (currently Yoast SEO);
+	 * the SEO options are no-ops otherwise. Kept abstracted so other SEO
+	 * plugins can be added here later. Props @JeroenSormani.
+	 */
+	public static function should_show_seo_tab(){
+		return defined( 'WPSEO_VERSION' );
+	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -96,6 +96,7 @@ You can try our <a href="https://wordpress.org/plugins/wp-image-compression/">Fr
 == Changelog ==
 = 2.0.2 =
 * Hardening: block direct access to all plugin PHP files.
+* The SEO tab now only appears when a supported SEO plugin (Yoast SEO) is active, and fixed a settings message typo. Props @JeroenSormani.
 * Refreshed the plugin description.
 
 = 2.0.1 =


### PR DESCRIPTION
Reimplements the still-valid parts of #7 adapted to the 2.0 codebase: gate the SEO tab on an active SEO plugin, and fix the Deactivation typo. Folds into the un-tagged 2.0.2 (no version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)